### PR TITLE
Update default rpc and examples to sepolia

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,18 +105,18 @@ this:
 
 ```sh
 # Deploy the contract.
-cast send --rpc-url https://stylusv2.arbitrum.io/rpc --private-key <private-key> --create <koba output>
+cast send --rpc-url https://sepolia-rollup.arbitrum.io/rpc --private-key <private-key> --create <koba output>
 
 # Activate the contract.
-cast send --rpc-url https://stylusv2.arbitrum.io/rpc --private-key <private-key> --value "0.0001ether" 0x0000000000000000000000000000000000000071 "activateProgram(address)(uint16,uint256)" <contract address>
+cast send --rpc-url https://sepolia-rollup.arbitrum.io/rpc --private-key <private-key> --value "0.0001ether" 0x0000000000000000000000000000000000000071 "activateProgram(address)(uint16,uint256)" <contract address>
 
 # Interact with the contract
-cast call --rpc-url https://stylusv2.arbitrum.io/rpc <contract address> "number()"
+cast call --rpc-url https://sepolia-rollup.arbitrum.io/rpc <contract address> "number()"
 0x0000000000000000000000000000000000000000000000000000000000000005
 
-cast send --rpc-url https://stylusv2.arbitrum.io/rpc --private-key <private-key> <contract address> "increment()"
+cast send --rpc-url https://sepolia-rollup.arbitrum.io/rpc --private-key <private-key> <contract address> "increment()"
 
-cast storage --rpc-url https://stylusv2.arbitrum.io/rpc <contract address> 0
+cast storage --rpc-url https://sepolia-rollup.arbitrum.io/rpc <contract address> 0
 0x0000000000000000000000000000000000000000000000000000000000000006
 ```
 
@@ -127,10 +127,10 @@ with the appropriate arguments to deploy and activate your Stylus contract in
 one go:
 
 ```sh
-$ koba deploy --sol <path-to-constructor> --wasm <path-to-wasm> --args <constructor-arguments> -e https://stylusv2.arbitrum.io/rpc --private-key <private-key>
+$ koba deploy --sol <path-to-constructor> --wasm <path-to-wasm> --args <constructor-arguments> -e https://sepolia-rollup.arbitrum.io/rpc --private-key <private-key>
 wasm data fee: Ξ0.000113
 init code size: 20.8 KB
-deploying to RPC: https://stylusv2.arbitrum.io/rpc
+deploying to RPC: https://sepolia-rollup.arbitrum.io/rpc
 deployed code: 0x470AE56DFbea924722423926782D8aB30f108A49
 deployment tx hash: 0xb52a68b973fb883dbef6bf3e0cbee4f02608ae71ad5a89f6a2f0c9f094242a5b
 activated with 2987042 gas

--- a/src/config.rs
+++ b/src/config.rs
@@ -53,7 +53,7 @@ pub struct Generate {
     pub legacy: bool,
 }
 
-const STYLUS_TESTNET_RPC: &str = "https://stylusv2.arbitrum.io/rpc";
+const STYLUS_TESTNET_RPC: &str = "https://sepolia-rollup.arbitrum.io/rpc";
 
 /// Deploy & activate a Stylus contract.
 #[derive(Parser, Debug)]


### PR DESCRIPTION
The stylus testnet has long been shutdown and the default should be sepolia.